### PR TITLE
增加一个静态文件缓存方案

### DIFF
--- a/framework/App.php
+++ b/framework/App.php
@@ -26,9 +26,9 @@ class App{
 	}
 
 	static function init(){
-		$version_file = APP_PATH . '/../version';
+		$version_file = APP_PATH . '/../md5.json';
 		if(file_exists($version_file)){
-			self::$version = trim(@file_get_contents($version_file));
+			self::$version = json_decode(@file_get_contents($version_file), true);
 		}
 		// before any exception
 		self::$context = new Context();

--- a/framework/Html.php
+++ b/framework/Html.php
@@ -87,7 +87,8 @@ class Html{
 			$url = self::base_url() . '/' . $url;
 		}
 		if(App::$version && !isset($param['_v']) && self::is_static_resource($url)){
-			$param['_v'] = App::$version;
+			$relative_path = substr($url, strlen(self::base_url().'/'));
+			$param['_v'] = App::$version[$relative_path];
 		}
 		if($param){
 			if(strpos($url, '?')){

--- a/tools/resourece_md5.php
+++ b/tools/resourece_md5.php
@@ -1,0 +1,119 @@
+<?php
+/*
+	生成当前工作目录下的js、css文件md5映射表
+	默认是当前目录下的js、css、static文件夹，可传入参数更改
+	在工作目录下调用 php /data/lib/iphp/tools/resourece_md5.php dir1 dir2...
+	md5.json生成在当前目录下
+*/
+
+$cwd = getcwd();
+$md5_file_name = 'md5.json';
+$static_dir = array('js', 'css', 'static');
+$extnames = array('js', 'css');
+$MD5 = array();
+
+if ($argc > 1) {
+	$static_dir = array_slice($argv, 1);
+}
+
+walk_dir($static_dir, 'resolve_file');
+file_put_contents('md5.json', json_format(json_encode($MD5)));
+echo 'generated file ' . $cwd . "/md5.json !\n";
+
+function walk_dir($path, $callback) {
+	if (is_array($path)) {
+		foreach ($path as $p) {
+			walk_dir($p, $callback);
+		}
+	} elseif (is_string($path)) {
+		if (file_exists($path)) {
+			if (is_dir($path)) {
+				$files = scandir($path);
+				for ($i=0, $l=count($files); $i < $l; $i++) { 
+					if ($files[$i] == '.' || $files[$i] == '..') {
+						array_splice($files, $i, 1);
+						$i--;
+						$l--;
+					} else {
+						$files[$i] = $path . '/' . $files[$i];
+					}
+				}
+				walk_dir($files, $callback);
+			} elseif (is_file($path)) {
+				call_user_func($callback, $path);
+			}
+		}
+	}
+}
+
+function resolve_file($file) {
+	$extname = pathinfo($file, PATHINFO_EXTENSION);
+	if (in_array($extname, $GLOBALS['extnames'])) {
+		$GLOBALS['MD5'][$file] = md5_file($file);
+	}
+}
+
+//pretty json,  PHP version >= 5.4 can use json_encode($json, JSON_PRETTY_PRINT);
+function json_format($json) { 
+	$tab = "  "; 
+	$new_json = ""; 
+	$indent_level = 0; 
+	$in_string = false; 
+
+	$json_obj = json_decode($json); 
+
+	if($json_obj === false) 
+		return false; 
+
+	$json = json_encode($json_obj); 
+	$len = strlen($json); 
+
+	for($c = 0; $c < $len; $c++) { 
+		$char = $json[$c]; 
+		switch($char) { 
+			case '{': 
+			case '[': 
+				if(!$in_string) { 
+					$new_json .= $char . "\n" . str_repeat($tab, $indent_level+1); 
+					$indent_level++; 
+				} 
+				else { 
+					$new_json .= $char; 
+				} 
+				break; 
+			case '}': 
+			case ']': 
+				if(!$in_string) { 
+					$indent_level--; 
+					$new_json .= "\n" . str_repeat($tab, $indent_level) . $char; 
+				} 
+				else { 
+					$new_json .= $char; 
+				} 
+				break; 
+			case ',': 
+				if(!$in_string) { 
+					$new_json .= ",\n" . str_repeat($tab, $indent_level); 
+				} else { 
+					$new_json .= $char; 
+				} 
+				break; 
+			case ':': 
+				if(!$in_string) { 
+					$new_json .= ": "; 
+				} 
+				else { 
+					$new_json .= $char; 
+				} 
+				break; 
+			case '"': 
+				if($c > 0 && $json[$c-1] != '\\') { 
+					$in_string = !$in_string; 
+				} 
+			default: 
+				$new_json .= $char; 
+				break;                    
+		} 
+	} 
+	return $new_json; 
+} 


### PR DESCRIPTION
先用iphp/tools/resourece_md5.php脚本在项目根目录生成静态文件的md5值映射表
用iphp _url()方法引用的静态资源会在请求url上增加该文件的md5值作为查询参数
每当有静态资源修改时，重新运行脚本生成md5.json文件，就可以解决对应文件的缓存问题